### PR TITLE
chatspaceのDB設計の記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Things you may want to cover:
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :group
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -22,3 +22,45 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+# chatspace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, add_index|
+|email|string|null: false, unique: true|
+|password|string|null: false, unique: true|
+### Association
+- has_many :groups_users
+- has_many :groups, through: :groups_users
+- has_many :messages
+
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+|email|string|null: false, unique: true|
+|message_id|intger|null: false, foreign_key: true|
+### Association
+- has_many :groups_users
+- has_many :users, through: :groups_users
+- has_many :messages
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
-|email|string|null: false, unique: true|
-|message_id|intger|null: false, foreign_key: true|
+|name|string|null: false|
 ### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Things you may want to cover:
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :group
 - belongs_to :user


### PR DESCRIPTION
# What
chatspaceの作成において必要なDBのテーブルの詳細をREADME.mdに記載しました。

chatspaceの機能
・ユーザ管理機能
・グループ管理機能
・メッセージ機能
主な機能は上記の３つだと考えたので、
usersテーブル
groups_usersテーブル
groupsテーブル
messagesテーブル
の４つのテーブルについて詳細を記述しました。

userテーブルのnameカラムにはインデックスを貼りました。
これはグループメンバー追加時にメンバーを検索する際に名前で検索するので、必要と考えたためです。
# Why
chatspaceの機能がどのようなDBで設計されているか明確にするため。